### PR TITLE
Avoid allocation for constants

### DIFF
--- a/src/Numeric/AD/DelCont/Native/Linear.hs
+++ b/src/Numeric/AD/DelCont/Native/Linear.hs
@@ -75,8 +75,8 @@ infixl 7 ^/
 (^/) = op2' L.zero (L.^+^) (+) $ \v c ->
   (v L.^/ c, (L.^/ c), \dz -> (-dz `L.dot` v / (c * c)))
 
-zero :: (L.Additive v, L.Additive u, Num a, Num da) => AD' s (v a) (u da)
-zero = konst' L.zero L.zero
+zero :: (L.Additive v, Num a) => AD' s (v a) (u da)
+zero = konst L.zero
 
 sumV ::
   (Foldable t, L.Additive v, L.Additive u, Num a, Num da) =>


### PR DESCRIPTION
This PR is only for a record; this only resulted in both time and space overhead by the branching.